### PR TITLE
Fix recursive call in TREE-COLLECT

### DIFF
--- a/quickutil-utilities/utilities/trees.lisp
+++ b/quickutil-utilities/utilities/trees.lisp
@@ -51,5 +51,5 @@
               :if (funcall predicate item) collect item
                 :else
                   :if (listp item)
-                    :append (recursive-find/collect predicate item)))))
+                    :append (tree-collect predicate item)))))
   %%%)


### PR DESCRIPTION
The function was renamed when it was added to quickutil but the recursive call
inside it wasn't updated.

Fixes https://github.com/tarballs-are-good/quickutil/issues/53